### PR TITLE
CMR-5231: Change references of echo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See public/licenses.txt
 ### Initial setup
 Once the repository is cloned locally and Ruby 2.1.2 is installed, you must install the dependencies.
 If you don't have the [bundler](http://bundler.io/) gem already installed, execute the command below in the project root directory:
-   
+
     gem install bundler   
 
 or if you wish to install the bundler without documentation:
@@ -127,8 +127,8 @@ that the application needs in order to run.  A sample _config/application.yml_ f
     current: &current
         opensearch_url: http://localhost:3000/
         catalog_rest_endpoint: https://cmr.earthdata.nasa.gov/search/
-        echo_rest_endpoint: https://api.echo.nasa.gov/echo-rest/
-        contact: echodev@echo.nasa.gov
+        echo_rest_endpoint: https://cmr.earthdata.nasa.gov/legacy-services/rest/
+        contact: support@earthdata.nasa.gov
         mode: dev
         public_catalog_rest_endpoint: https://cmr.earthdata.nasa.gov/search/
         release_page: https://wiki.earthdata.nasa.gov/display/echo/Open+Search+API+release+information

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -18,6 +18,6 @@ class Token
   end
 
   def self.delete(token_id)
-    RestClient.delete "https://api.echo.nasa.gov/echo-rest/tokens/#{token_id}", {:echo_token => token_id}
+    RestClient.delete "https://cmr.earthdata.nasa.gov/legacy-services/rest/tokens/#{token_id}", {:echo_token => token_id}
   end
 end

--- a/app/views/home/docs.html.erb
+++ b/app/views/home/docs.html.erb
@@ -191,7 +191,7 @@
     be validated for compliance with all off the <a href="#specs-of-interest">Specifications of interest</a> by
     providing the URL
     of the OSDD to be validated to the
-    <a target="_blank" class="ext" href="http://api.echo.nasa.gov/cwic-smart/validations">CWICSmart OSDD validation
+    <a target="_blank" class="ext" href="https://opensearch-ui.earthdata.nasa.gov/validations">CWICSmart OSDD validation
       tool</a>.
   </p>
   <p>The tool will provide individual validation scores for OpenSearch features as well as an overall validation score.
@@ -207,7 +207,7 @@
       <li>
         <a target="_blank" class="ext" href="http://api.echo.nasa.gov/cwic-smart/assets/OpenSearch.xsd">OpenSearch.xsd</a>
         was developed
-        by developed by the <a target="_blank" class="ext" href="http://api.echo.nasa.gov/cwic-smart/">CWICSmart</a>
+        by developed by the <a target="_blank" class="ext" href="https://opensearch-ui.earthdata.nasa.gov/">CWICSmart</a>
         team based on an existing public domain schema at
         <a target="_blank" class="ext" href="http://weblogs.asp.net/wkriebel/archive/2008/02/04/opensearch-xsd.aspx">http://weblogs.asp.net/wkriebel/archive/2008/02/04/opensearch-xsd.aspx</a>
       </li>
@@ -230,7 +230,8 @@
     Becuase the
     <a class="ext" target="_blank" href='https://portal.opengeospatial.org/files/65168'>OGC OpenSearch extension for
       Earth Observation</a>
-    and the<a class="ext" target="_blank" href='http://www.opengeospatial.org/standards/opensearchgeo'>OGC OpenSearch
+    and the
+    <a class="ext" target="_blank" href='http://www.opengeospatial.org/standards/opensearchgeo'>OGC OpenSearch
     Geo and Time extensions</a>
     specifications are in different maturity levels, their individual RELAX NG schemas have not yet been unified into
     a single set of RELAX NG schemas that can be applied to both specifications.

--- a/config/application.rb
+++ b/config/application.rb
@@ -214,8 +214,8 @@ module EchoOpensearch
     end
     update_env('opensearch_url', 'http://localhost:3000')
     update_env('catalog_rest_endpoint', 'https://cmr.earthdata.nasa.gov/search/')
-    update_env('echo_rest_endpoint','https://api.echo.nasa.gov/echo-rest/')
-    update_env('contact','echodev@echo.nasa.gov')
+    update_env('echo_rest_endpoint','https://cmr.earthdata.nasa.gov/legacy-services/rest/')
+    update_env('contact','support@earthdata.nasa.gov')
     update_env('public_catalog_rest_endpoint','https://cmr.earthdata.nasa.gov/search/')
     update_env('release_page', 'https://wiki.earthdata.nasa.gov/display/echo/Open+Search+API+release+information')
     update_env('documentation_page','https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home')

--- a/config/application.yml.template
+++ b/config/application.yml.template
@@ -1,7 +1,7 @@
 current: &current
   opensearch_url: http://localhost:3000
   catalog_rest_endpoint: https://cmr.earthdata.nasa.gov/search/
-  echo_rest_endpoint: https://api.echo.nasa.gov/echo-rest/
+  echo_rest_endpoint: https://cmr.earthdata.nasa.gov/legacy-services/rest/
   contact: @MAIL_SENDER@
   mode: @MODE@
   public_catalog_rest_endpoint: https://cmr.earthdata.nasa.gov/search/


### PR DESCRIPTION
There are still a lot of references to echo.nasa.gov in tests (i left those alone). I also was not able to find the following resources at all:

http://api.echo.nasa.gov/cwic-smart/assets/*

These are in the opensearch documentation found here:
https://cmr.earthdata.nasa.gov/opensearch/home/docs#schemas

Not sure if they exist anymore. if not I will remove that section. 