### PR TITLE
CMR-8089: Re-comments configuration for Production

### DIFF
--- a/app/helpers/granules_helper.rb
+++ b/app/helpers/granules_helper.rb
@@ -64,12 +64,12 @@ module GranulesHelper
   #
   # @return [String] The url found within a correctly utilized related url object
   def determine_granule_url_by_related_url(collection)
-    return if collection.fetch('relatedUrls', []).empty?
+    return if collection.fetch('relatedUrls', []).blank?
 
     related_urls = collection.fetch('relatedUrls', []).select { |url| (url['urlContentType'] && url['urlContentType'] == 'DistributionURL') && (url['subtype'] && url['subtype'] == 'OpenSearch') }
 
     # Return a url if one was found within the related urls
-    return related_urls.first['url'] unless related_urls.empty?
+    return related_urls.first['url'] unless related_urls.blank?
   end
 
   # determine_granule_url_by_tags
@@ -238,7 +238,7 @@ module GranulesHelper
     errors = parsed_response.fetch('errors', [])
 
     # If any errors are returned return the error template
-    unless errors.empty?
+    unless errors.blank?
       return {
         'error' => errors[0].fetch('message'),
         'erb_file' => 'error.xml.erb'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # config.active_record.dump_schema_after_migration = false
 
   config.relative_url_root = '/opensearch'
   config.graphql_endpoint = ENV['GRAPHQL_ENDPOINT']

--- a/config/initializers/holdings_scheduler.rb
+++ b/config/initializers/holdings_scheduler.rb
@@ -72,7 +72,7 @@ unless scheduler.down?
       cwic_providers_cache = {}
 
       [
-        # { 'provider' => 'FEDEO',   'params' => { 'providers'   => %w[FEDEO ESA] } },
+        { 'provider' => 'FEDEO',   'params' => { 'providers'   => %w[FEDEO ESA] } },
         { 'provider' => 'IRSO',    'params' => { 'dataCenters' => %w[IN/ISRO/NRSC-BHUVAN IN/ISRO/NDC IN/ISRO/MOSDAC] } },
         { 'provider' => 'NRSCC',   'params' => { 'provider'    => 'NRSCC' } },
         { 'provider' => 'USGSLSI', 'params' => { 'provider'    => 'USGS_LTA' } }


### PR DESCRIPTION
As part of the Ruby update, I uncommented a configuration that was not necessary. That configuration is causing issues in production so this PR re-comments it. 

It also changes a few log messages and `empty` checks to better account for `blank` values.