### PR TITLE
CMR-10630: modifies contact to doug newman, and updates opensearch.org links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The CMR OpenSearch documentation page is at:
 ## About
 CMR OpenSearch is a web application developed by [NASA](http://nasa.gov) [EOSDIS](https://earthdata.nasa.gov)
 to enable data discovery, search, and access across Earth Science data holdings by using an open standard.
-It provides an interface compliant with the [OpenSearch 1.1 (Draft 5) specification](https://www.opensearch.org/Home)
+It provides an interface compliant with the [OpenSearch 1.1 (Draft 5) specification](https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/1.1/Draft%205.wiki)
 by taking advantage of NASA's [Common Metadata Repository (CMR)](https://cmr.earthdata.nasa.gov/search/) APIs for data discovery and access.
 
 ## License

--- a/app/views/collections/descriptor_document.xml.erb
+++ b/app/views/collections/descriptor_document.xml.erb
@@ -5,7 +5,7 @@
   xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
   xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
   xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-  xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+  xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
   xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
   xmlns:atom="http://www.w3.org/2005/Atom">
   <os:ShortName>CMR Collections</os:ShortName>

--- a/app/views/collections/descriptor_document_facets.xml.erb
+++ b/app/views/collections/descriptor_document_facets.xml.erb
@@ -5,7 +5,7 @@
   xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
   xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
   xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-  xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+  xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
   xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
   xmlns:atom="http://www.w3.org/2005/Atom"
   xmlns:sru="http://docs.oasis-open.org/ns/search-ws/facetedResults" >

--- a/app/views/granules/descriptor_document.xml.erb
+++ b/app/views/granules/descriptor_document.xml.erb
@@ -5,7 +5,7 @@
   xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
   xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
   xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-  xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+  xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
   xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
   xmlns:atom="http://www.w3.org/2005/Atom">
   <os:ShortName>CMR Granules</os:ShortName>

--- a/app/views/home/docs.html.erb
+++ b/app/views/home/docs.html.erb
@@ -16,7 +16,7 @@
 <section>
   <h2><a name="overview"/>CMR OpenSearch Overview</h2>
   <p>CMR OpenSearch is a CMR collections and granules search implementation based on the
-    <a class="ext" target="_blank" href='http://www.opensearch.org/Home'>OpenSearch 1.1 (Draft 5) specification</a>. It
+    <a class="ext" target="_blank" href='https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/1.1/Draft%205.wiki'>OpenSearch 1.1 (Draft 5) specification</a>. It
     allows clients to formulate OpenSearch compliant queries against the CMR collections and granules inventory and
     specify
     the desired search results format as OpenSearch compliant
@@ -32,19 +32,19 @@
   <h3><a name="specs-of-interest"/>Specifications of interest</h3>
   <p>CMR OpenSearch is compliant with the following specifications, best practices and implementation guides:
   <ul>
-    <li><a class="ext" target="_blank" href='http://www.opensearch.org/Home'>OpenSearch 1.1 (Draft 5) specification</a>
+    <li><a class="ext" target="_blank" href='https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/1.1/Draft%205.wiki'>OpenSearch 1.1 (Draft 5) specification</a>
     </li>
     <li>
-      <a class="ext" target="_blank" href='http://www.opensearch.org/Specifications/OpenSearch/Extensions/Geo/1.0/Draft_2'>OpenSearch
+      <a class="ext" target="_blank" href='https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Geo/1.0/Draft%202.wiki'>OpenSearch
         Geo extension 1.0 (Draft 2)</a></li>
     <li>
-      <a class="ext" target="_blank" href='http://www.opensearch.org/Specifications/OpenSearch/Extensions/Time/1.0/Draft_1'>OpenSearch
+      <a class="ext" target="_blank" href='https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Time/1.0/Draft%201.wiki'>OpenSearch
         Time extension 1.0 (Draft 1)</a></li>
     <li>
-      <a class="ext" target="_blank" href='http://www.opensearch.org/Specifications/OpenSearch/Extensions/Parameter/1.0'>OpenSearch
+      <a class="ext" target="_blank" href='https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Parameter/1.0/Draft%202.wiki'>OpenSearch
         Parameter extension 1.0 (Draft 1)</a></li>
     <li>
-      <a class="ext" target="_blank" href='http://www.opensearch.org/Specifications/OpenSearch/Extensions/Relevance/1.0/Draft_1'>OpenSearch
+      <a class="ext" target="_blank" href='http://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Relevance/1.0/Draft%201.wiki'>OpenSearch
         Relevance extension 1.0 (Draft 1)</a></li>
     <li>
       <a class="ext" target="_blank" href='http://www.opengeospatial.org/standards/opensearchgeo'>OGC OpenSearch Geo and

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <aside class="sidebar-container">
   <p>
-    CMR provides a search interface based on the <a class="ext" target="_blank" href='http://www.opensearch.org/Home'>OpenSearch</a> concept in
+    CMR provides a search interface based on the <a class="ext" target="_blank" href='https://github.com/dewitt/opensearch'>OpenSearch</a> concept in
     general and the ESIP (Earth Science Information
     Partners) <a class="ext" target="_blank" href='http://wiki.esipfed.org/index.php/Federated_Search'>federated search</a> concept in particular.
     Usage details and sample CMR OpenSearch invocations are available in the <%= link_to "CMR OpenSearch documentation page", home_docs_path %>.
@@ -8,7 +8,7 @@
 
   <div class="extended-content">
     <p>
-      From the <a class="ext" target="_blank" href='http://www.opensearch.org/Specifications/OpenSearch/1.1'>Open Search draft specification</a>,
+      From the <a class="ext" target="_blank" href='https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/1.1/Draft%205.wiki'>Open Search draft specification</a>,
 
     <blockquote>OpenSearch is a collection of simple formats for the sharing of search results.
       You can use Open Search formats to help people discover and use your search engine and to syndicate search results
@@ -17,7 +17,7 @@
     </p>
     <p>
       Open Search uses Open Search Descriptor Documents (OSDDs) to describe the web interface of a search engine.
-      We use <a class="ext" target="_blank" href='http://www.opensearch.org/Specifications/OpenSearch/1.1'>Open Search 1.1</a> to provide OSDDs at
+      We use <a class="ext" target="_blank" href='https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/1.1/Draft%205.wiki'>Open Search 1.1</a> to provide OSDDs at
       the
       collection and granule level for searching the CMR inventory.
     </p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -241,7 +241,7 @@ module EchoOpensearch
     update_env('public_catalog_rest_endpoint','https://cmr.earthdata.nasa.gov/search/')
     update_env('release_page', 'https://wiki.earthdata.nasa.gov/display/echo/Open+Search+API+release+information')
     update_env('documentation_page','https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home')
-    update_env('organization_contact_name','Stephen Berrick')
+    update_env('organization_contact_name','Doug Newman')
 
   end
 end

--- a/config/application.yml.template
+++ b/config/application.yml.template
@@ -12,8 +12,8 @@ current: &current
   documentation_page: https://wiki.earthdata.nasa.gov/display/CMR/Common+Metadata+Repository+Home
   display_banner: '@DISPLAY_BANNER@'
   organization: NASA EOSDIS
-  organization_contact_email: stephen.w.berrick@nasa.gov
-  organization_contact_name: Stephen Berrick
+  organization_contact_email: douglas.j.newman@nasa.gov
+  organization_contact_name: Doug Newman
 
 development:
   <<: *current

--- a/features/home/home.feature
+++ b/features/home/home.feature
@@ -9,6 +9,6 @@ Scenario: View Home Page
   And I should see "CMR provides a search interface based on the OpenSearch concept in general and the ESIP (Earth Science Information Partners) federated search concept in particular."
   And I should see the subtitle "Collections"
   And I should see the subtitle "Granules"
-  And I should see "NASA Official: Stephen Berrick"
+  And I should see "NASA Official: Doug Newman"
   And I should see the current version of CMR
   And I should see a link to the CMR OpenSearch release documentation

--- a/features/opensearch_descriptor_documents/step_definitions/opensearch_descriptor_documents_steps.rb
+++ b/features/opensearch_descriptor_documents/step_definitions/opensearch_descriptor_documents_steps.rb
@@ -38,7 +38,7 @@ Then /^I should see a collection open search descriptor document for client id "
     xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
     xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
     xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-    xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+    xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
     xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
     xmlns:atom="http://www.w3.org/2005/Atom" >
     <os:ShortName>CMR Collections</os:ShortName>
@@ -151,7 +151,7 @@ Then /^I should see a granule open search descriptor document for client id "([^
       xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
       xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
       xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-      xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+      xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
       xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
       xmlns:atom="http://www.w3.org/2005/Atom" >
       <os:ShortName>CMR Granules</os:ShortName>
@@ -225,7 +225,7 @@ Then /^I should see a granule open search descriptor document for client id "([^
       xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
       xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
       xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-      xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+      xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
       xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
       xmlns:atom="http://www.w3.org/2005/Atom" >
       <os:ShortName>CMR Granules</os:ShortName>
@@ -299,7 +299,7 @@ Then /^I should see a granule open search descriptor document for client id "([^
       xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
       xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
       xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-      xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+      xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
       xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
       xmlns:atom="http://www.w3.org/2005/Atom">
       <os:ShortName>CMR Granules</os:ShortName>
@@ -373,7 +373,7 @@ Then /^I should see a granule open search descriptor document for client id "([^
       xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
       xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
       xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-      xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+      xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
       xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
       xmlns:atom="http://www.w3.org/2005/Atom" >
       <os:ShortName>CMR Granules</os:ShortName>

--- a/spec/views/collections/descriptor_document_facets_spec.rb
+++ b/spec/views/collections/descriptor_document_facets_spec.rb
@@ -22,7 +22,7 @@ describe 'collections/descriptor_document_facets' do include Rack::Test::Methods
         xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
         xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
         xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-        xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+        xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
         xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
         xmlns:atom="http://www.w3.org/2005/Atom"
         xmlns:sru="http://docs.oasis-open.org/ns/search-ws/facetedResults" >

--- a/spec/views/collections/descriptor_document_spec.rb
+++ b/spec/views/collections/descriptor_document_spec.rb
@@ -18,7 +18,7 @@ describe 'collections/descriptor_document' do
         xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
         xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
         xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-        xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+        xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
         xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
         xmlns:atom="http://www.w3.org/2005/Atom" >
         <os:ShortName>CMR Collections</os:ShortName>

--- a/spec/views/granules/descriptor_document_no_client_spec.rb
+++ b/spec/views/granules/descriptor_document_no_client_spec.rb
@@ -24,7 +24,7 @@ describe "granules/descriptor_document" do
                     xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
                     xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
                     xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-                    xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+                    xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
                     xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
                     xmlns:atom="http://www.w3.org/2005/Atom">
                     <os:ShortName>CMR Granules</os:ShortName>
@@ -134,7 +134,7 @@ describe "granules/descriptor_document" do
           xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
           xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
           xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-          xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+          xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
           xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
           xmlns:atom="http://www.w3.org/2005/Atom" >
           <os:ShortName>CMR Granules</os:ShortName>

--- a/spec/views/granules/descriptor_document_spec.rb
+++ b/spec/views/granules/descriptor_document_spec.rb
@@ -23,7 +23,7 @@ describe "granules/descriptor_document" do
         xmlns:geo="http://a9.com/-/opensearch/extensions/geo/1.0/"
         xmlns:time="http://a9.com/-/opensearch/extensions/time/1.0/"
         xmlns:params="http://a9.com/-/spec/opensearch/extensions/parameters/1.0/"
-        xmlns:referrer="http://www.opensearch.org/Specifications/OpenSearch/Extensions/Referrer/1.0"
+        xmlns:referrer="https://github.com/dewitt/opensearch/blob/master/mediawiki/Specifications/OpenSearch/Extensions/Referrer/1.0"
         xmlns:eo="http://a9.com/-/opensearch/extensions/eo/1.0/"
         xmlns:atom="http://www.w3.org/2005/Atom" >
         <os:ShortName>CMR Granules</os:ShortName>


### PR DESCRIPTION
# Overview

### What is the feature/fix?

opensearch.org links need to be modified to point to github equivalent links, Doug Newman should be added in as nasa point of contact

### What is the Solution?

Global replace of opensearch.org links, slight modification to the url to make the wiki links usable.  Replacing Stephen Berrick's name  and email with Doug Newmans's.
